### PR TITLE
FIN-283 Update rollbar gem

### DIFF
--- a/lib/rollbar_helper/version.rb
+++ b/lib/rollbar_helper/version.rb
@@ -1,3 +1,3 @@
 module RollbarHelper
-  VERSION = '0.3.0'
+  VERSION = '1.0.0'
 end

--- a/rollbar_helper.gemspec
+++ b/rollbar_helper.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.11"
-  spec.add_dependency "rollbar", "~> 2.13"
+  spec.add_dependency "rollbar", "~> 3.2"
 end


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/FIN-283

Our team noticed these [rollbar errors](https://rollbar.com/snapsheettech/snapsheet-tx/items/4956/). This occurs in [many of our environments](https://rollbar.com/snapsheettech/all/items/?sort=%5Bobject%20Object%5D&status=active&enc_query=X3uRV4C%2Fr9lg9xE46WtciWp9s8v%2FQSmyJRprw86J5OwlUU9dpXjIuI%2BsL3ocfQGD&date_from=&date_to=&environments=demo&environments=development--&environments=development--development&environments=development-eu-1-development&environments=integration&environments=production&environments=production--zurich-integration&environments=production-eu-1-production&environments=production-eu-1-zurich-integration&environments=pwc-demo&environments=pwc-dev&environments=pwc_demo&environments=pwc_dev&environments=pwcdev&environments=qa1&environments=qa2&environments=qa2--qa2&environments=qa3&environments=qa4&environments=qa5&environments=qa6&environments=qa7&environments=release&environments=release-eu-1-stage&environments=seed&environments=stage&environments=stage--stage&environments=stage-eu-1-qa&environments=stage-eu-1-stage&environments=system&environments=test&environments=testing_tinker&environments=uat&environments=uat--uat&environments=unspecified&environments=zurich&environments=zurich-integration&activated_to=&timezone=America%2FNew_York&framework=&levels=40&levels=50&activated_from=&offset=0&query=failsafe%20from%20rollbar-gem&assigned_user=&date_filtering=seen&projects=101897&projects=111485&projects=114603&projects=121483&projects=124156&projects=132034&projects=141367&projects=143045&projects=144026&projects=144598&projects=162962&projects=16361&projects=16362&projects=16363&projects=163752&projects=168821&projects=171373&projects=17590&projects=183422&projects=200005&projects=202489&projects=206737&projects=218693&projects=24198&projects=254560&projects=258164&projects=258759&projects=261647&projects=276885&projects=287965&projects=31831&projects=33657&projects=345709&projects=355114&projects=36201&projects=395626&projects=485813&projects=59604&projects=69814&projects=75643&projects=99816) when rollbar is having an incident. [This github issue](https://github.com/rollbar/rollbar-gem/pull/951) suggests that we need to upgrade our rollbar gem to fix the issue. Since we are already updating rollbar, I'm going to update the dependency to the latest rollbar version. Looking at the [release notes](https://github.com/rollbar/rollbar-gem/releases), the breaking change to version 3.0 removes support for Ruby 1.9.3 which none of our repositories should still be on anyways.

# Testing

1. update the gem in your repository to `gem 'rollbar_helper', :path => '../rollbar_helper'`
2. in the rails console test sending some rollbars, you will want to do it from creating different methods in the rails console otherwise they will get lumped together, these are some examples I ran
```
def send_info
   RollbarHelper.info('Test new rollbar version')
end

send_info

def send_error
   RollbarHelper.error('Test new rollbar version', user_name: 'Carrie Utter')
end

send_error

def send_warning
   RollbarHelper.warn('Test new rollbar version', user_name: 'Carrie Utter')
end

send_warning

def send_critical
   RollbarHelper.critical('Test new rollbar version', user_name: 'Carrie Utter')
end

send_critical
```

Since no CI is run here is the passing tests
<img width="566" alt="Screen Shot 2021-10-07 at 1 39 08 PM" src="https://user-images.githubusercontent.com/19717455/136435809-b21e51c5-6ab2-491c-a856-20cfd12a455f.png">


