### PR TITLE
Support for sending both an exception and a plain message. Add Core legacy support too

### DIFF
--- a/lib/rollbar_helper.rb
+++ b/lib/rollbar_helper.rb
@@ -14,7 +14,7 @@ module RollbarHelper
     LEVELS.each do |level|
       define_method(level) do |*args|
         message, exception, extra = extract_arguments(args)
-        extra = {callee: caller}.merge(extra)
+        extra = { callee: caller }.merge(extra)
         data, exception, callee, fingerprint = split_extra_arg(extra, exception)
 
         if !message.nil? && exception.nil?
@@ -30,7 +30,7 @@ module RollbarHelper
 
     def log(level, *args)
       raise ArgumentError, 'Log level is not supported' unless LEVELS.include?(level.to_sym)
-      send(level, {callee: caller}, *args)
+      send(level, { callee: caller }, *args)
     end
 
     private

--- a/lib/rollbar_helper.rb
+++ b/lib/rollbar_helper.rb
@@ -3,55 +3,65 @@ require 'rollbar_helper/version'
 
 module RollbarHelper
   LEVELS = [
-    :critical,
     :debug,
-    :error,
     :info,
     :warning,
-  ]
+    :error,
+    :critical,
+  ].freeze
 
   class << self
-    def critical(obj, fingerprint: nil, **data)
-      log(:critical, obj, :callee => caller, fingerprint: fingerprint, **data)
+    LEVELS.each do |level|
+      define_method(level) do |*args|
+        message, exception, extra = extract_arguments(args)
+        extra = {callee: caller}.merge(extra)
+        data, exception, callee, fingerprint = split_extra_arg(extra, exception)
+
+        if !message.nil? && exception.nil?
+          exception = StandardError.new(message).tap do |e|
+            e.set_backtrace(callee)
+          end
+          message = nil
+        end
+
+        get_notifier(fingerprint).public_send(level, message, exception, data)
+      end
     end
 
-    def debug(obj, fingerprint: nil, **data)
-      log(:debug, obj, :callee => caller, fingerprint: fingerprint, **data)
+    def log(level, *args)
+      raise ArgumentError, 'Log level is not supported' unless LEVELS.include?(level.to_sym)
+      send(level, {callee: caller}, *args)
     end
 
-    def error(obj, fingerprint: nil, **data)
-      log(:error, obj, :callee => caller, fingerprint: fingerprint, **data)
-    end
+    private
 
-    def info(obj, fingerprint: nil, **data)
-      log(:info, obj, :callee => caller, fingerprint: fingerprint, **data)
-    end
+    def extract_arguments(args)
+      message = exception = nil
+      extra = {}
 
-    def warn(obj, fingerprint: nil, **data)
-      log(:warning, obj, :callee => caller, fingerprint: fingerprint, **data)
-    end
-
-    def warning(obj, fingerprint: nil, **data)
-      log(:warning, obj, :callee => caller, fingerprint: fingerprint, **data)
-    end
-
-    def log(level, obj, callee: caller, fingerprint: nil, **data)
-      level = level.to_sym
-      raise ArgumentError, 'Log level is not supported' unless LEVELS.include?(level)
-      e = nil
-
-      if obj.is_a?(Exception)
-        e = obj
-      else
-        e = StandardError.new(obj.to_s)
-        e.set_backtrace(callee)
+      args.each do |arg|
+        if arg.is_a?(String)
+          message = arg
+        elsif arg.is_a?(Exception)
+          exception = arg
+        elsif arg.is_a?(Hash)
+          extra = extra.merge(arg)
+        end
       end
 
-      unless fingerprint.nil?
-        ::Rollbar.scope(:fingerprint => fingerprint).send(level, e, data)
-      else
-        ::Rollbar.send(level, e, data)
-      end
+      [message, exception, extra]
+    end
+
+    def split_extra_arg(extra, exception)
+      exception ||= extra.delete(:e) # Core legacy support
+      callee = extra.delete(:callee)
+      fingerprint = extra.delete(:fingerprint)
+      [extra, exception, callee, fingerprint]
+    end
+
+    def get_notifier(fingerprint)
+      return Rollbar if fingerprint.nil?
+      Rollbar.scope(fingerprint: fingerprint)
     end
   end
 end

--- a/lib/rollbar_helper/version.rb
+++ b/lib/rollbar_helper/version.rb
@@ -1,3 +1,3 @@
 module RollbarHelper
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/rollbar_helper_spec.rb
+++ b/spec/rollbar_helper_spec.rb
@@ -7,43 +7,68 @@ RSpec::Matchers.define :caller_backtrace do |expected|
 end
 
 RSpec.describe RollbarHelper do
+  let(:data) { {data: true} }
+
+  before(:each) do
+    allow_any_instance_of(Rollbar::Notifier).to receive(:enabled?).and_return(true)
+  end
+
+
   it "has a version number" do
     expect(RollbarHelper::VERSION).not_to be nil
   end
 
   it 'responds to log level methods' do
+    expect(RollbarHelper.respond_to?(:debug)).to    eq(true)
+    expect(RollbarHelper.respond_to?(:info)).to     eq(true)
+    expect(RollbarHelper.respond_to?(:warning)).to  eq(true)
+    expect(RollbarHelper.respond_to?(:error)).to    eq(true)
     expect(RollbarHelper.respond_to?(:critical)).to eq(true)
-    expect(RollbarHelper.respond_to?(:debug)).to eq(true)
-    expect(RollbarHelper.respond_to?(:error)).to eq(true)
-    expect(RollbarHelper.respond_to?(:info)).to eq(true)
-    expect(RollbarHelper.respond_to?(:warning)).to eq(true)
+  end
+
+  it 'support sending both a message and an exception' do
+    expect(Rollbar).to receive(:error).with('Oops!', instance_of(StandardError), data).and_call_original
+    expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+    RollbarHelper.error('Oops!', StandardError.new('Error'), data)
+  end
+
+  context '#core legacy' do
+    it 'support sending both a message and an exception' do
+      expect(Rollbar).to receive(:error).with('Oops!', instance_of(StandardError), data).and_call_original
+      expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+      RollbarHelper.error('Oops!', data.merge(e: StandardError.new('Error')))
+    end
   end
 
   it 'wraps rollbar method with error' do
-    expect(Rollbar).to receive(:error).with(instance_of(StandardError), :data => true)
-    RollbarHelper.error('Oops!', :data => true)
+    expect(Rollbar).to receive(:error).with(nil, instance_of(StandardError), data).and_call_original
+    expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+    RollbarHelper.error('Oops!', data)
   end
 
   it 'uses callers backtrace' do
-    expect(Rollbar).to receive(:error).with(caller_backtrace(__FILE__), :data => true)
-    RollbarHelper.error('Oops!', :data => true)
+    expect(Rollbar).to receive(:error).with(nil, caller_backtrace(__FILE__), data).and_call_original
+    expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+    RollbarHelper.error('Oops!', data)
   end
 
   it 'scopes with fingerprint' do
-    expect(Rollbar).to receive(:scope).with(:fingerprint => 'processor').and_return(Rollbar)
-    expect(Rollbar).to receive(:error).with(caller_backtrace(__FILE__), :data => true)
-    RollbarHelper.error('Oops!', :fingerprint => 'processor', :data => true)
+    expect(Rollbar).to receive(:scope).with(:fingerprint => 'processor').and_call_original
+    expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(nil, caller_backtrace(__FILE__), data).and_call_original
+    expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+    RollbarHelper.error('Oops!', data, :fingerprint => 'processor')
   end
 
   describe '#log' do
     it 'uses callers backtrace' do
-      expect(Rollbar).to receive(:error).with(caller_backtrace(__FILE__), :data => true)
-      RollbarHelper.log(:error, 'Oops!', :data => true)
+      expect(Rollbar).to receive(:error).with(nil, caller_backtrace(__FILE__), data).and_call_original
+      expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
+      RollbarHelper.log(:error, 'Oops!', data)
     end
 
     it 'raises on unsupported log levels' do
       expect {
-        RollbarHelper.log(:silly, 'Oops!', :data => true)
+        RollbarHelper.log(:silly, 'Oops!', data)
       }.to raise_error(ArgumentError, 'Log level is not supported')
     end
   end

--- a/spec/rollbar_helper_spec.rb
+++ b/spec/rollbar_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe RollbarHelper do
 
   before(:each) do
     allow_any_instance_of(Rollbar::Notifier).to receive(:enabled?).and_return(true)
+    allow_any_instance_of(Rollbar::Configuration).to receive(:transmit).and_return(false)
   end
 
 
@@ -53,10 +54,10 @@ RSpec.describe RollbarHelper do
   end
 
   it 'scopes with fingerprint' do
-    expect(Rollbar).to receive(:scope).with(:fingerprint => 'processor').and_call_original
+    expect(Rollbar).to receive(:scope).with(fingerprint: 'processor').and_call_original
     expect_any_instance_of(Rollbar::Notifier).to receive(:error).with(nil, caller_backtrace(__FILE__), data).and_call_original
     expect_any_instance_of(Rollbar::Item).to receive(:build_backtrace_body).and_call_original
-    RollbarHelper.error('Oops!', data, :fingerprint => 'processor')
+    RollbarHelper.error('Oops!', data, fingerprint: 'processor')
   end
 
   describe '#log' do


### PR DESCRIPTION
## What/Why

Currently, `RollbarHelper` only supports receiving an object (exception or string message), but the `Rollbar` gem actually supports receiving both.

Additionally, Core plans to start using that Gem but in many places, we've been passing:
- a string for the main object
- an exception via an `:e` key in the `data` hash

## How

Refactor this code to follow more closely `Rollbar`'s gem implementation (using the same signature) while still getting the nice to have that Snapsheet added:
- providing `fingerprint` as part of the `data` hash
- including the stack trace when sending a rollbar without an exception

## Testing

Specs should be passing:

<img width="465" alt="image" src="https://github.com/user-attachments/assets/23f11beb-483e-4738-ad51-caa90b1660cd">
